### PR TITLE
feat:　リモ達達成状況の更新APIの作成

### DIFF
--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 // use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use App\Services\UpdateTasksService;
+use Illuminate\Support\Facades\Validator;
 
 class UserController extends Controller
 {
@@ -16,12 +17,21 @@ class UserController extends Controller
         $this->UpdateTasksService = $updateTasksService;
     }
 
+    public function tasks_validates(Request $request)
+    {
+        $request->validate([
+            'remotatsus_state.*.remotatsu_id' => 'required|integer|exists:remotatsus,id',
+            'remotatsus_state.*.remotatsus_state' => 'required|integer',
+        ]);
+
+    }
+
     public function update_tasks(Request $request)
     {
         DB::beginTransaction();
         try
         {
-            // TODO: requestをそのまま渡さない
+            $this->tasks_validates($request);
             $tasks = $this->UpdateTasksService->update_tasks($request->remotatsus_state);
             DB::commit();
             return $tasks;

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Log;
+
+class UserController extends Controller
+{
+    public function update_tasks(Request $request)
+    {
+        $user_id = Auth::id();
+        DB::beginTransaction();
+        try
+        {
+            $remotatsu_tasks = DB::table('remotatsu_tasks');
+            $remotatsu_tasks->where('user_id', $user_id)->delete();
+            $remotatsus_state = $request->remotatsus_state;
+
+            foreach($remotatsus_state as $state)
+            {
+                if($state["remotatsus_state"] === 0) continue;
+                $remotatsu_tasks->insert([
+                    'user_id' => $user_id,
+                    'remotatsu_id' => $state["remotatsu_id"]
+                ]);
+            }
+            $user = User::find($user_id);
+            $tasks = $user->remotatsus;
+            DB::commit();
+            return $tasks;
+        }catch(\Exception $e){
+            DB::rollBack();
+            throw $e;
+        }
+    }
+}

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -3,37 +3,31 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
-use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
+// use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Log;
+use App\Services\UpdateTasksService;
 
 class UserController extends Controller
 {
+    private $UpdateTasksService;
+    public function __construct(UpdateTasksService $updateTasksService)
+    {
+        $this->UpdateTasksService = $updateTasksService;
+    }
+
     public function update_tasks(Request $request)
     {
-        $user_id = Auth::id();
         DB::beginTransaction();
         try
         {
-            $remotatsu_tasks = DB::table('remotatsu_tasks');
-            $remotatsu_tasks->where('user_id', $user_id)->delete();
-            $remotatsus_state = $request->remotatsus_state;
-
-            foreach($remotatsus_state as $state)
-            {
-                if($state["remotatsus_state"] === 0) continue;
-                $remotatsu_tasks->insert([
-                    'user_id' => $user_id,
-                    'remotatsu_id' => $state["remotatsu_id"]
-                ]);
-            }
-            $user = User::find($user_id);
-            $tasks = $user->remotatsus;
+            // TODO: requestをそのまま渡さない
+            $tasks = $this->UpdateTasksService->update_tasks($request->remotatsus_state);
             DB::commit();
             return $tasks;
-        }catch(\Exception $e){
+        }
+        catch(\Exception $e)
+        {
             DB::rollBack();
             throw $e;
         }

--- a/app/Models/Remotatsu.php
+++ b/app/Models/Remotatsu.php
@@ -11,6 +11,10 @@ class Remotatsu extends Model
 
     public function users()
     {
-        return $this->belongsToMany(User::class, 'remotatsu_tasks', 'user_id', 'remotatsu_id');
+        return
+            $this->belongsToMany
+            (
+                User::class, 'remotatsu_tasks'
+            );
     }
 }

--- a/app/Models/RemotatsuTask.php
+++ b/app/Models/RemotatsuTask.php
@@ -8,4 +8,5 @@ use Illuminate\Database\Eloquent\Model;
 class RemotatsuTask extends Model
 {
     use HasFactory;
+    protected $fillable = ['user_id', 'remotatsu_id'];
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,6 +22,10 @@ class User extends Authenticatable
     }
 
     public function remotatsus(){
-        return $this->belongsToMany(Remotatsu::class, 'remotatsu_tasks', 'remotatsu_id', 'user_id');
+        return
+            $this->belongsToMany
+            (
+                Remotatsu::class, 'remotatsu_tasks'
+            );
     }
 }

--- a/app/Services/UpdateTasksService.php
+++ b/app/Services/UpdateTasksService.php
@@ -1,0 +1,29 @@
+<?php
+namespace App\Services;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class UpdateTasksService
+{
+    public function update_tasks($remotatsus_state)
+    {
+        $user_id = Auth::id();
+        $remotatsu_tasks = DB::table('remotatsu_tasks');
+        $remotatsu_tasks->where('user_id', $user_id)->delete();
+
+        foreach($remotatsus_state as $state)
+        {
+            if($state["remotatsus_state"] === 0) continue;
+            $remotatsu_tasks->insert([
+                'user_id' => $user_id,
+                'remotatsu_id' => $state["remotatsu_id"]
+            ]);
+        }
+        $user = User::find($user_id);
+        $tasks = $user->remotatsus;
+        return $tasks;
+    }
+}

--- a/app/Services/UpdateTasksService.php
+++ b/app/Services/UpdateTasksService.php
@@ -2,22 +2,21 @@
 namespace App\Services;
 use App\Http\Controllers\Controller;
 use App\Models\User;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use App\Models\RemotatsuTask;
 
 class UpdateTasksService
 {
     public function update_tasks($remotatsus_state)
     {
         $user_id = Auth::id();
-        $remotatsu_tasks = DB::table('remotatsu_tasks');
-        $remotatsu_tasks->where('user_id', $user_id)->delete();
+        RemotatsuTask::where('user_id', $user_id)->delete();
 
         foreach($remotatsus_state as $state)
         {
             if($state["remotatsus_state"] === 0) continue;
-            $remotatsu_tasks->insert([
+            RemotatsuTask::create([
                 'user_id' => $user_id,
                 'remotatsu_id' => $state["remotatsu_id"]
             ]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,3 +18,4 @@ use App\Http\Controllers\AuthController;
 
 Route::post('/login', [AuthController::class, 'login']);
 Route::middleware('auth:sanctum')->get('/remotatsus', [RemotatsuController::class, 'index']);
+Route::middleware('auth:sanctum')->post('/remotatsus_state', [UserController::class, 'update_tasks']);


### PR DESCRIPTION
## やったこと
リモ達の達成状況を更新するAPIの作成。
<!-- * このプルリクで何をしたのか？ -->

## やらないこと
なし
<!-- * このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## できるようになること（ユーザ目線）
リモ達の達成状況を更新できるようになる。
Bodyに
```json
{
"remotatsu_state": [{"remotatsu_id": 1, "remotatsu_state": 1}, 
                                  {"remotatsu_id":2, "remotatsu_state": 0},
                               ...]
}
```
のようなJSONを付してPOSTする。
`remotatsu_state`が０は未達成、１は達成。
`"achieved": [1, 3, 5, ...]`のように達成した`remotatsu_id`の配列を渡すことも考えたが、「未達成だけど優先的にやる！」のような気持ちのステータスなどを増やしたい時に拡張しにくそうなので、今の設計にしてみた。
<!-- * 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）
なし
<!-- * 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
postmanを用いて、`localhost/api/remotatsus_state`にPOST リクエストを送信し、DBの中をみる。
<!-- * どのような動作確認を行ったのか？　結果はどうか？ -->

## その他

- 今日までの経験上、for文でInsertを何度も行うという処理があまり良くなさそう？
- RemotatsuTaskModel を作って、そこで`RemotatsuTaskModel::create(...)` のような実装の方が良い？
