### PR TITLE
feat: ユーザーの投票可否を返すAPIを実装

### DIFF
--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -7,14 +7,16 @@ use Illuminate\Http\Request;
 // use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use App\Services\UpdateTasksService;
-use Illuminate\Support\Facades\Validator;
+use App\Services\GetCanVoteService;
 
 class UserController extends Controller
 {
     private $UpdateTasksService;
-    public function __construct(UpdateTasksService $updateTasksService)
+    private $GetCanVoteService;
+    public function __construct(UpdateTasksService $updateTasksService, GetCanVoteService $getCanVoteService)
     {
         $this->UpdateTasksService = $updateTasksService;
+        $this->GetCanVoteService = $getCanVoteService;
     }
 
     public function tasks_validates(Request $request)
@@ -41,5 +43,10 @@ class UserController extends Controller
             DB::rollBack();
             throw $e;
         }
+    }
+
+    public function get_can_vote(Request $request)
+    {
+        return $this->GetCanVoteService->get_can_vote();
     }
 }

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 // use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use App\Services\UpdateTasksService;
+use Illuminate\Support\Facades\Validator;
 
 class UserController extends Controller
 {
@@ -16,12 +17,21 @@ class UserController extends Controller
         $this->UpdateTasksService = $updateTasksService;
     }
 
+    public function tasks_validates(Request $request)
+    {
+        $request->validate([
+            'remotatsus_state.*.remotatsu_id' => 'required|integer|exists:remotatsus,id',
+            'remotatsus_state.*.remotatsus_state' => 'required|integer',
+        ]);
+
+    }
+
     public function update_tasks(Request $request)
     {
         DB::beginTransaction();
         try
         {
-            // TODO: requestをそのまま渡さない
+            $this->tasks_validates($request);
             $tasks = $this->UpdateTasksService->update_tasks($request->remotatsus_state);
             DB::commit();
             return $tasks;

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Log;
+
+class UserController extends Controller
+{
+    public function update_tasks(Request $request)
+    {
+        $user_id = Auth::id();
+        DB::beginTransaction();
+        try
+        {
+            $remotatsu_tasks = DB::table('remotatsu_tasks');
+            $remotatsu_tasks->where('user_id', $user_id)->delete();
+            $remotatsus_state = $request->remotatsus_state;
+
+            foreach($remotatsus_state as $state)
+            {
+                if($state["remotatsus_state"] === 0) continue;
+                $remotatsu_tasks->insert([
+                    'user_id' => $user_id,
+                    'remotatsu_id' => $state["remotatsu_id"]
+                ]);
+            }
+            $user = User::find($user_id);
+            $tasks = $user->remotatsus;
+            DB::commit();
+            return $tasks;
+        }catch(\Exception $e){
+            DB::rollBack();
+            throw $e;
+        }
+    }
+}

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -3,37 +3,31 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
-use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
+// use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Log;
+use App\Services\UpdateTasksService;
 
 class UserController extends Controller
 {
+    private $UpdateTasksService;
+    public function __construct(UpdateTasksService $updateTasksService)
+    {
+        $this->UpdateTasksService = $updateTasksService;
+    }
+
     public function update_tasks(Request $request)
     {
-        $user_id = Auth::id();
         DB::beginTransaction();
         try
         {
-            $remotatsu_tasks = DB::table('remotatsu_tasks');
-            $remotatsu_tasks->where('user_id', $user_id)->delete();
-            $remotatsus_state = $request->remotatsus_state;
-
-            foreach($remotatsus_state as $state)
-            {
-                if($state["remotatsus_state"] === 0) continue;
-                $remotatsu_tasks->insert([
-                    'user_id' => $user_id,
-                    'remotatsu_id' => $state["remotatsu_id"]
-                ]);
-            }
-            $user = User::find($user_id);
-            $tasks = $user->remotatsus;
+            // TODO: requestをそのまま渡さない
+            $tasks = $this->UpdateTasksService->update_tasks($request->remotatsus_state);
             DB::commit();
             return $tasks;
-        }catch(\Exception $e){
+        }
+        catch(\Exception $e)
+        {
             DB::rollBack();
             throw $e;
         }

--- a/app/Models/Remotatsu.php
+++ b/app/Models/Remotatsu.php
@@ -11,6 +11,10 @@ class Remotatsu extends Model
 
     public function users()
     {
-        return $this->belongsToMany(User::class, 'remotatsu_tasks', 'user_id', 'remotatsu_id');
+        return
+            $this->belongsToMany
+            (
+                User::class, 'remotatsu_tasks'
+            );
     }
 }

--- a/app/Models/RemotatsuTask.php
+++ b/app/Models/RemotatsuTask.php
@@ -8,4 +8,5 @@ use Illuminate\Database\Eloquent\Model;
 class RemotatsuTask extends Model
 {
     use HasFactory;
+    protected $fillable = ['user_id', 'remotatsu_id'];
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,6 +22,10 @@ class User extends Authenticatable
     }
 
     public function remotatsus(){
-        return $this->belongsToMany(Remotatsu::class, 'remotatsu_tasks', 'remotatsu_id', 'user_id');
+        return
+            $this->belongsToMany
+            (
+                Remotatsu::class, 'remotatsu_tasks'
+            );
     }
 }

--- a/app/Services/GetCanVoteService.php
+++ b/app/Services/GetCanVoteService.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Services;
+use App\Models\User;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
+
+class GetCanVoteService
+{
+    public function get_can_vote()
+    {
+        $minimum_achievements_number = 15;
+        $user_id = Auth::id();
+        $user = User::find($user_id);
+        $remotatsus = $user->remotatsus;
+        return count($remotatsus) >= $minimum_achievements_number;
+    }
+}

--- a/app/Services/GetCanVoteService.php
+++ b/app/Services/GetCanVoteService.php
@@ -6,12 +6,12 @@ use Illuminate\Support\Facades\Auth;
 
 class GetCanVoteService
 {
+    private const MINIMUM_ACHIEVEMENTS_NUMBER = 15;
     public function get_can_vote()
     {
-        $minimum_achievements_number = 15;
         $user_id = Auth::id();
         $user = User::find($user_id);
         $remotatsus = $user->remotatsus;
-        return count($remotatsus) >= $minimum_achievements_number;
+        return count($remotatsus) >= self::MINIMUM_ACHIEVEMENTS_NUMBER;
     }
 }

--- a/app/Services/GetCanVoteService.php
+++ b/app/Services/GetCanVoteService.php
@@ -6,12 +6,12 @@ use Illuminate\Support\Facades\Auth;
 
 class GetCanVoteService
 {
+    private const minimum_achievements_number = 15;
     public function get_can_vote()
     {
-        $minimum_achievements_number = 15;
         $user_id = Auth::id();
         $user = User::find($user_id);
         $remotatsus = $user->remotatsus;
-        return count($remotatsus) >= $minimum_achievements_number;
+        return count($remotatsus) >= self::minimum_achievements_number;
     }
 }

--- a/app/Services/UpdateTasksService.php
+++ b/app/Services/UpdateTasksService.php
@@ -1,0 +1,29 @@
+<?php
+namespace App\Services;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class UpdateTasksService
+{
+    public function update_tasks($remotatsus_state)
+    {
+        $user_id = Auth::id();
+        $remotatsu_tasks = DB::table('remotatsu_tasks');
+        $remotatsu_tasks->where('user_id', $user_id)->delete();
+
+        foreach($remotatsus_state as $state)
+        {
+            if($state["remotatsus_state"] === 0) continue;
+            $remotatsu_tasks->insert([
+                'user_id' => $user_id,
+                'remotatsu_id' => $state["remotatsu_id"]
+            ]);
+        }
+        $user = User::find($user_id);
+        $tasks = $user->remotatsus;
+        return $tasks;
+    }
+}

--- a/app/Services/UpdateTasksService.php
+++ b/app/Services/UpdateTasksService.php
@@ -2,22 +2,21 @@
 namespace App\Services;
 use App\Http\Controllers\Controller;
 use App\Models\User;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use App\Models\RemotatsuTask;
 
 class UpdateTasksService
 {
     public function update_tasks($remotatsus_state)
     {
         $user_id = Auth::id();
-        $remotatsu_tasks = DB::table('remotatsu_tasks');
-        $remotatsu_tasks->where('user_id', $user_id)->delete();
+        RemotatsuTask::where('user_id', $user_id)->delete();
 
         foreach($remotatsus_state as $state)
         {
             if($state["remotatsus_state"] === 0) continue;
-            $remotatsu_tasks->insert([
+            RemotatsuTask::create([
                 'user_id' => $user_id,
                 'remotatsu_id' => $state["remotatsu_id"]
             ]);

--- a/database/seeders/RemotatsuSeeder.php
+++ b/database/seeders/RemotatsuSeeder.php
@@ -18,7 +18,7 @@ class RemotatsuSeeder extends Seeder
      */
     public function run()
     {
-        for($i = 0; $i < 10; $i++){
+        for($i = 0; $i < 100; $i++){
             Remotatsu::create([
                 'remotatsu_name' => Str::random(10),
                 'description' => Str::random(10),

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -23,9 +23,9 @@ class UserSeeder extends Seeder
             ['role_name' => 'Admin'],
         );
         User::create([
-                'employee_code' => Str::random(10),
-                'user_name' => Str::random(10),
-                'email' => Str::random(10) . '@gmail.com',
+                'employee_code' => 'C0117035',
+                'user_name' => 'ShutaIto',
+                'email' =>  'c011703534@gmail.com',
                 'password' => Hash::make('password'),
                 'role_id' => $admin->id,
         ]);

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -25,7 +25,7 @@ class UserSeeder extends Seeder
         User::create([
                 'employee_code' => 'C0117035',
                 'user_name' => 'ShutaIto',
-                'email' =>  'c011703534@gmail.com',
+                'email' =>  'c011703534@edu.teu.ac.jp',
                 'password' => Hash::make('password'),
                 'role_id' => $admin->id,
         ]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,3 +18,4 @@ use App\Http\Controllers\AuthController;
 
 Route::post('/login', [AuthController::class, 'login']);
 Route::middleware('auth:sanctum')->get('/remotatsus', [RemotatsuController::class, 'index']);
+Route::middleware('auth:sanctum')->post('/remotatsus_state', [UserController::class, 'update_tasks']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,3 +19,4 @@ use App\Http\Controllers\AuthController;
 Route::post('/login', [AuthController::class, 'login']);
 Route::middleware('auth:sanctum')->get('/remotatsus', [RemotatsuController::class, 'index']);
 Route::middleware('auth:sanctum')->post('/remotatsus_state', [UserController::class, 'update_tasks']);
+Route::middleware('auth:sanctum')->get('/can_vote', [UserController::class, 'get_can_vote']);


### PR DESCRIPTION
## やったこと
ユーザーが宝くじに投票可能かを判定するAPIを実装
<!-- * このプルリクで何をしたのか？ -->


## やらないこと
なし
<!-- * このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## できるようになること（ユーザ目線）
自身が宝くじに応募可能かを知ることができる
<!-- * 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）
なし
<!-- * 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
postmanでリクエストを送信し、レスポンスをみた。
この際、`minimum_achivement_number`変数を変更し、投票の可否が切り替わっていることを確認した。
<!-- * どのような動作確認を行ったのか？　結果はどうか？ -->

## その他
- rebaseがちゃんとできているか（networkを見るとできていそうな気がする）
- `feature/update_remotatsu`ブランチでの変更もfile changedに入ってしまったので、レビューしにくいかもです

<!-- * レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載 -->
