### PR TITLE
feat: 自然数ゲームのための応募APIの実装

### DIFF
--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use App\Services\UpdateTasksService;
 use App\Services\GetCanVoteService;
 use App\Services\VoteLottery;
+use \Symfony\Component\HttpFoundation\Response;
 
 class UserController extends Controller
 {
@@ -69,6 +70,12 @@ class UserController extends Controller
         try
         {
             $this->vote_validate($request);
+            if(!$this->GetCanVoteService->get_can_vote())
+            {
+                return response()->json([
+                    'message' => 'You do not meet the application requirements.'
+                ], Response::HTTP_METHOD_NOT_ALLOWED);
+            }
             $this->VoteLottery->vote($request->number);
             DB::commit();
         }

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -70,21 +70,14 @@ class UserController extends Controller
         try
         {
             $this->vote_validate($request);
-            if(!$this->GetCanVoteService->get_can_vote())
-            {
-                return response()->json([
-                    'message' => 'You do not meet the application requirements.'
-                ], Response::HTTP_METHOD_NOT_ALLOWED);
-            }
-            $this->VoteLottery->vote($request->number);
+            $res = $this->VoteLottery->vote($request->number);
             DB::commit();
+            return $res;
         }
         catch(\Exception $e)
         {
             DB::rollBack();
             throw $e;
         }
-
-
     }
 }

--- a/app/Http/Controllers/API/UserController.php
+++ b/app/Http/Controllers/API/UserController.php
@@ -8,23 +8,23 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use App\Services\UpdateTasksService;
 use App\Services\GetCanVoteService;
-use App\Services\VoteLottery;
+use App\Services\VoteLotteryService;
 use \Symfony\Component\HttpFoundation\Response;
 
 class UserController extends Controller
 {
     private $UpdateTasksService;
     private $GetCanVoteService;
-    private $VoteLottery;
+    private $VoteLotteryService;
     public function __construct(
         UpdateTasksService $updateTasksService,
         GetCanVoteService $getCanVoteService,
-        VoteLottery $voteLottery
+        VoteLotteryService $voteLotteryService
     )
     {
         $this->UpdateTasksService = $updateTasksService;
         $this->GetCanVoteService = $getCanVoteService;
-        $this->VoteLottery = $voteLottery;
+        $this->VoteLotteryService = $voteLotteryService;
     }
 
     public function tasks_validates(Request $request)
@@ -70,7 +70,7 @@ class UserController extends Controller
         try
         {
             $this->vote_validate($request);
-            $res = $this->VoteLottery->vote($request->number);
+            $res = $this->VoteLotteryService->vote($request->number);
             DB::commit();
             return $res;
         }

--- a/app/Models/Vote.php
+++ b/app/Models/Vote.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class Vote extends Model
 {
     use HasFactory;
+    protected $fillable = ['vote_number'];
 
     public function user(){
         return $this->belongsTo(User::class);

--- a/app/Services/GetCanVoteService.php
+++ b/app/Services/GetCanVoteService.php
@@ -11,6 +11,7 @@ class GetCanVoteService
     {
         $user_id = Auth::id();
         $user = User::find($user_id);
+        if(!is_null($user->vote)) return false;
         $remotatsus = $user->remotatsus;
         return count($remotatsus) >= self::MINIMUM_ACHIEVEMENTS_NUMBER;
     }

--- a/app/Services/VoteLottery.php
+++ b/app/Services/VoteLottery.php
@@ -20,10 +20,9 @@ class VoteLottery
         if(!$this->GetCanVoteService->get_can_vote())
         {
             return response()->json([
-                'message' => 'You do not meet the application requirements.'
+                'message' => 'You do not meet the application requirements or already voted.'
             ], Response::HTTP_METHOD_NOT_ALLOWED);
         }
-        echo "success";
         $user_id = Auth::id();
         $user = User::find($user_id);
         $user->vote()->create([

--- a/app/Services/VoteLottery.php
+++ b/app/Services/VoteLottery.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Services;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+class VoteLottery
+{
+    public function vote($vote_number)
+    {
+        $user_id = Auth::id();
+        $user = User::find($user_id);
+        $user->vote()->create([
+            'vote_number' => $vote_number
+        ]);
+    }
+}

--- a/app/Services/VoteLottery.php
+++ b/app/Services/VoteLottery.php
@@ -3,15 +3,34 @@ namespace App\Services;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
+use App\Services\GetCanVoteService;
+use \Symfony\Component\HttpFoundation\Response;
 
 class VoteLottery
 {
+    private $GetCanVoteService;
+    public function __construct(
+        GetCanVoteService $getCanVoteService,
+    )
+    {
+        $this->GetCanVoteService = $getCanVoteService;
+    }
     public function vote($vote_number)
     {
+        if(!$this->GetCanVoteService->get_can_vote())
+        {
+            return response()->json([
+                'message' => 'You do not meet the application requirements.'
+            ], Response::HTTP_METHOD_NOT_ALLOWED);
+        }
+        echo "success";
         $user_id = Auth::id();
         $user = User::find($user_id);
         $user->vote()->create([
             'vote_number' => $vote_number
         ]);
+        return response()->json([
+            'message' => 'OK'
+        ], Response::HTTP_ACCEPTED);
     }
 }

--- a/app/Services/VoteLotteryService.php
+++ b/app/Services/VoteLotteryService.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Auth;
 use App\Services\GetCanVoteService;
 use \Symfony\Component\HttpFoundation\Response;
 
-class VoteLottery
+class VoteLotteryService
 {
     private $GetCanVoteService;
     public function __construct(

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,4 +20,4 @@ Route::post('/login', [AuthController::class, 'login']);
 Route::middleware('auth:sanctum')->get('/remotatsus', [RemotatsuController::class, 'index']);
 Route::middleware('auth:sanctum')->post('/remotatsus_state', [UserController::class, 'update_tasks']);
 Route::middleware('auth:sanctum')->get('/can_vote', [UserController::class, 'get_can_vote']);
-Route::middleware('auth:sanctum')->post('/vote', [UserController::class, 'vote']);
+Route::middleware('auth:sanctum')->post('/lottery', [UserController::class, 'vote']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,3 +20,4 @@ Route::post('/login', [AuthController::class, 'login']);
 Route::middleware('auth:sanctum')->get('/remotatsus', [RemotatsuController::class, 'index']);
 Route::middleware('auth:sanctum')->post('/remotatsus_state', [UserController::class, 'update_tasks']);
 Route::middleware('auth:sanctum')->get('/can_vote', [UserController::class, 'get_can_vote']);
+Route::middleware('auth:sanctum')->post('/vote', [UserController::class, 'vote']);


### PR DESCRIPTION
## やったこと
自然数ゲームのための応募APIの実装。
応募条件を満たしているか判断し、`request->number`が自然数であるかをvalidateした後にDBに保存を行う。
また、 #7 にて、すでに投票済の場合も再投票を可能とするAPIとなっていたので、修正した。
<!-- * このプルリクで何をしたのか？ -->

## やらないこと
なし
<!-- * このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## できるようになること（ユーザ目線）
自然数の投票



<!-- * 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
なし
## できなくなること（ユーザ目線）

<!-- * 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
postmanにてリクエストを送信し、tinkerにてDBの中身を確認した。
また、以下の条件のいずれかを満たすとき、エラーが返ってくることを確認した。
- 投票の条件にある、リモ達達成数を変更し満たしていない場合
- すでに投票済の場合
- 自然数でない場合

<!-- * どのような動作確認を行ったのか？　結果はどうか？ -->

## その他
なし
<!-- * レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載 -->
