### PR TITLE
優勝者（当選者）の自然数、IDの取得APIを実装

### DIFF
--- a/app/Http/Controllers/API/VoteController.php
+++ b/app/Http/Controllers/API/VoteController.php
@@ -23,5 +23,6 @@ class VoteController extends Controller
 
     public function get_winner(Request $request)
     {
+        return $this->GetWinnerInfoService->get_winner();
     }
 }

--- a/app/Http/Controllers/API/VoteController.php
+++ b/app/Http/Controllers/API/VoteController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Services\GetWinnerInfoService;
+
+class VoteController extends Controller
+{
+    private $GetWinnerInfoService;
+    public function __construct(
+        GetWinnerInfoService $getWinnerInfoService
+    )
+    {
+        $this->GetWinnerInfoService= $getWinnerInfoService;
+    }
+
+    public function get_winner_number(Request $request)
+    {
+        return $this->GetWinnerInfoService->get_winner_number();
+    }
+
+    public function get_winner(Request $request)
+    {
+    }
+}

--- a/app/Services/GetWinnerInfoService.php
+++ b/app/Services/GetWinnerInfoService.php
@@ -1,0 +1,29 @@
+<?php
+namespace App\Services;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use App\Models\Vote;
+
+class GetWinnerInfoService
+{
+    public function get_winner_number()
+    {
+        $voted_numbers = Vote::select('vote_number')
+            ->get()->pluck('vote_number')->all();
+        $winner_number = PHP_INT_MAX;
+        $counts = array_count_values($voted_numbers);
+        foreach($counts as $number => $count)
+        {
+            if($count >= 2) continue;
+            if($winner_number > $number) continue;
+            $winner_number = $number;
+        }
+        return $number;
+    }
+
+    public function get_winner()
+    {
+    }
+}

--- a/app/Services/GetWinnerInfoService.php
+++ b/app/Services/GetWinnerInfoService.php
@@ -25,5 +25,9 @@ class GetWinnerInfoService
 
     public function get_winner()
     {
+        $winner_number = $this->get_winner_number();
+        $winner = Vote::where('vote_number', $winner_number);
+        $winner_id = $winner->first()->toArray()['user_id'];
+        return $winner_id;
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,3 +21,5 @@ Route::middleware('auth:sanctum')->get('/remotatsus', [RemotatsuController::clas
 Route::middleware('auth:sanctum')->post('/remotatsus_state', [UserController::class, 'update_tasks']);
 Route::middleware('auth:sanctum')->get('/can_vote', [UserController::class, 'get_can_vote']);
 Route::middleware('auth:sanctum')->post('/lottery', [UserController::class, 'vote']);
+Route::middleware('auth:sanctum')->get('/winner_number', [VoteController::class, 'get_winner_number']);
+Route::middleware('auth:sanctum')->get('/winner', [VoteController::class, 'get_winner']);


### PR DESCRIPTION
## やったこと
以下の実装をした
- 優勝者の投票した自然数を取得するAPI
- 優勝者のuser_idを取得するAPI

<!-- * このプルリクで何をしたのか？ -->

## やらないこと
- user_idからuser_nameの取得
<!-- * このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->

## できるようになること（ユーザ目線）
優勝者の情報がわかるようになる

<!-- * 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->

## できなくなること（ユーザ目線）
なし
<!-- * 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->

## 動作確認
tinkerでDBに値を入れ、postmanでリクエストを送信しレスポンスを確認した。

<!-- * どのような動作確認を行ったのか？　結果はどうか？ -->

## その他
- 優勝者のuser_idを返しているか、このままではフロント側が優勝者の名前を知る術がない
- 名前を返すべきか、user_idから名前を返すAPIを実装すべきか
　- 後者を選ぼうかなと思っています。（直感的には主キーでやりとりした方が後々困らなそう）
- 名前を返す方が良い、またはこういう実装にした方が良いなどありましたら教えてください 🙇 
<!-- * レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載 -->
